### PR TITLE
Changed page name to Angular Snippets

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -39,7 +39,7 @@ const canonicalURL = new URL(Astro.url).href;
     <meta property="og:title" content={frontmatter.title} />
     <meta property="og:description" content={frontmatter.description} />
     <meta property="og:image" content={ogImageParams} />
-    <meta property="og:site_name" content="Astro Basic Blog Template" />
+    <meta property="og:site_name" content="Angular Snippets" />
     <meta property="og:locale" content="en_US" />
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content={canonicalURL} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,7 +28,7 @@ const canonicalURL = new URL(Astro.url).href;
     <meta property="og:description" content={description} />
     <meta property="og:image" content="/banner.png" />
     <meta property="og:image:alt" content="Preview of the template" />
-    <meta property="og:site_name" content="Astro Basic Blog Template" />
+    <meta property="og:site_name" content="Angular Snippets" />
     <meta property="og:locale" content="en_US" />
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content={canonicalURL} />


### PR DESCRIPTION
I changed the site name on the Astro configuration for the hyperlinks to have the correct name of the page and not the default Astro template one.

Before it looked like this:

![image](https://user-images.githubusercontent.com/64326713/222727291-654b305b-eeb8-4978-b032-4bef11050d71.png)
